### PR TITLE
Updated nuget library of SharpBrick.PoweredUp.Mobile to 4.0.5

### DIFF
--- a/src/SharpBrick.PoweredUp.Mobile.Examples.iOS/SharpBrick.PoweredUp.Mobile.Examples.iOS.csproj
+++ b/src/SharpBrick.PoweredUp.Mobile.Examples.iOS/SharpBrick.PoweredUp.Mobile.Examples.iOS.csproj
@@ -134,10 +134,6 @@
     <PackageReference Include="Xamarin.Essentials" Version="1.6.1" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\..\powered-up\src\SharpBrick.PoweredUp.Mobile\SharpBrick.PoweredUp.Mobile.csproj">
-      <Project>{F66A2B09-84B6-477D-9B15-926E771C7D80}</Project>
-      <Name>SharpBrick.PoweredUp.Mobile</Name>
-    </ProjectReference>
     <ProjectReference Include="..\SharpBrick.PoweredUp.Mobile.Examples\SharpBrick.PoweredUp.Mobile.Examples.csproj">
       <Project>{a66e2dc1-5e0d-480e-9a53-1b54d6729be4}</Project>
       <Name>SharpBrick.PoweredUp.Mobile.Examples</Name>

--- a/src/SharpBrick.PoweredUp.Mobile.Examples/SharpBrick.PoweredUp.Mobile.Examples.csproj
+++ b/src/SharpBrick.PoweredUp.Mobile.Examples/SharpBrick.PoweredUp.Mobile.Examples.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="Plugin.Permissions" Version="6.0.1" />
     <PackageReference Include="Prism.Forms" Version="8.0.0.1909" />
     <PackageReference Include="Prism.Unity.Forms" Version="8.0.0.1909" />
-    <PackageReference Include="SharpBrick.PoweredUp.Mobile" Version="4.0.0" />
+    <PackageReference Include="SharpBrick.PoweredUp.Mobile" Version="4.0.5" />
     <PackageReference Include="Xamarin.Forms" Version="5.0.0.2012" />
     <PackageReference Include="Xamarin.Essentials" Version="1.6.1" />
   </ItemGroup>


### PR DESCRIPTION
Hi @tthiery,

I updated the solution to use the freshly build nugets v4.0.5.
I recompiled and tested the solution on Android and iOS and it remains working :)
